### PR TITLE
Update build instructions for PHP 5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,14 +23,32 @@ hypernode.kill_gone_requests = 0
 ```
 
 
-BUILD INSTRUCTIONS
-==================
+# BUILD INSTRUCTIONS
 The buildsystem for this module uses debhelper scripts that are only available for Ubuntu 14.04 (trusty) and later. We still use 12.04 (precise) on Hypernode. If you need to build this module for precies, you need two additional dependencies: [php5-dev-5.5-buildscripts](https://github.com/ByteInternet/php5-dev-5.5-buildscripts) and [pkg-php-tools](http://packages.ubuntu.com/trusty/pkg-php-tools) from Ubuntu 14.04. Both packages are available in the Hypernode Precise repository. You also need to have the same major version of php5-dev installed as this module will be used with.
 
-Make sure you have a build environment set up for the target system. You can use instructions from [the wiki](https://wiki.byte.nl/mediawiki/Git-buildpackage_%28handmatig%29#Pbuilder_omgeving_voor_ubuntu_precise_.2812.04_LTS.29_maken_.28op_Debian_of_op_Ubuntu.29). **Make sure to enable the Hypernode repository** (deb http://ubuntu.byte.nl precise main hypernode php54).
+Make sure you have a build environment set up for the target system. You can use instructions from [the wiki](https://wiki.byte.nl/mediawiki/Git-buildpackage_%28handmatig%29#Pbuilder_omgeving_voor_ubuntu_precise_.2812.04_LTS.29_maken_.28op_Debian_of_op_Ubuntu.29).
 
-Then:
-`git-buildpackage --git-pbuilder --git-dist=precise --git-arch=amd64 --git-debian-branch=master`
+**Build the package for each phpapi we support!** See below:
+
+## PHP 5.4
+
+ * Enable the Hypernode repository with the **5.4** component
+  * export DIST=precise ARCH=amd64
+  * `git-pbuilder login --save-after-login`
+  * `echo "deb http://ubuntu.byte.nl precise main hypernode php54" > /etc/apt/sources.list`
+  * `git-pbuilder update`
+ * Build: `git-buildpackage --git-pbuilder --git-dist=$DIST --git-arch=$ARCH --git-debian-branch=master`
+ * Upload: `dput -c dput-php5-hypernode.cf --unchecked hypernode-precise-php54 ../php5-hypernode_$(dpkg-parsechangelog --show-field version --count 1)_amd64.changes`
+
+## PHP 5.5
+
+ * Enable the Hypernode repository with the **5.5** component
+  * export DIST=precise ARCH=amd64
+  * `git-pbuilder login --save-after-login`
+  * `echo "deb http://ubuntu.byte.nl precise main hypernode php55" > /etc/apt/sources.list`
+  * `git-pbuilder update`
+ * Build: `git-buildpackage --git-pbuilder --git-dist=$DIST --git-arch=$ARCH --git-debian-branch=master`
+ * Upload: `dput -c dput-php5-hypernode.cf --unchecked hypernode-precise-php55 ../php5-hypernode_$(dpkg-parsechangelog --show-field version --count 1)_amd64.changes`
 
 
 CREATING A NEW VERSION

--- a/dput-php5-hypernode.cf
+++ b/dput-php5-hypernode.cf
@@ -1,0 +1,15 @@
+[hypernode-precise-php54]
+method=scp
+fqdn=debian1.c1.internal
+login=root
+incoming=/srv/ubuntu/incoming/precise
+pre_upload_command=ssh root@debian1.c1.internal "/srv/ubuntu/clean_incoming.sh"
+post_upload_command=ssh root@debian1.c1.internal "cd /srv/ubuntu && reprepro --ignore=wrongdistribution --component php54 include precise incoming/precise/*.changes && /srv/ubuntu/clean_incoming.sh"
+
+[hypernode-precise-php55]
+method=scp
+fqdn=debian1.c1.internal
+login=root
+incoming=/srv/ubuntu/incoming/precise
+pre_upload_command=ssh root@debian1.c1.internal "/srv/ubuntu/clean_incoming.sh"
+post_upload_command=ssh root@debian1.c1.internal "cd /srv/ubuntu && reprepro --ignore=wrongdistribution --component php55 include precise incoming/precise/*.changes && /srv/ubuntu/clean_incoming.sh"


### PR DESCRIPTION
@allardhoeve 

This will build a package named _php5-hypernode_, regardless of the source package it is built against. By uploading it either to the _php54_ or to the _php55_ component, we make sure both versions are allowed in the repo, and the correct one will be installed.
