### PR TITLE
php8.0 compatibility

### DIFF
--- a/hypernode-src/hypernode.c
+++ b/hypernode-src/hypernode.c
@@ -136,8 +136,13 @@ PHP_RINIT_FUNCTION(hypernode)
 		char *http_host, *remote_addr;
 
 		// sapi_getenv will emalloc
+#if PHP_MAJOR_VERSION < 7
 		http_host = sapi_getenv("HTTP_HOST", strlen("HTTP_HOST") TSRMLS_CC);
 		remote_addr = sapi_getenv("REMOTE_ADDR", strlen("REMOTE_ADDR") TSRMLS_CC);
+#else
+		http_host = sapi_getenv("HTTP_HOST", strlen("HTTP_HOST"));
+		remote_addr = sapi_getenv("REMOTE_ADDR", strlen("REMOTE_ADDR"));
+#endif
 
 		php_syslog(LOG_NOTICE, "Terminated request %s %s%s%s%s because client at %s is already gone",
 				SG(request_info).request_method,


### PR DESCRIPTION
see related https://github.com/ByteInternet/php-hypernode/pull/3

```
configure: WARNING: unrecognized options: --disable-silent-rules, --disable-maintainer-mode, --disable-dependency-tracking
touch configure-5.6-stamp
dh override_dh_auto_configure --with php
make[1]: Leaving directory '/build/php-hypernode-20200721.074350'
   debian/rules override_dh_auto_build
make[1]: Entering directory '/build/php-hypernode-20200721.074350'
dh_auto_build --sourcedirectory=build-8.0
	cd build-8.0 && make -j1
make[2]: Entering directory '/build/php-hypernode-20200721.074350/build-8.0'
/bin/bash /build/php-hypernode-20200721.074350/build-8.0/libtool --mode=compile cc -I. -I/build/php-hypernode-20200721.074350/build-8.0 -I/build/php-hypernode-20200721.074350/build-8.0/include -I/build/php-hypernode-20200721.074350/build-8.0/main -I/build/php-hypernode-20200721.074350/build-8.0 -I/usr/include/php/20200930 -I/usr/include/php/20200930/main -I/usr/include/php/20200930/TSRM -I/usr/include/php/20200930/Zend -I/usr/include/php/20200930/ext -I/usr/include/php/20200930/ext/date/lib  -Wdate-time -D_FORTIFY_SOURCE=2 -DHAVE_CONFIG_H  -g -O2 -fdebug-prefix-map=/build/php-hypernode-20200721.074350=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -pedantic    -c /build/php-hypernode-20200721.074350/build-8.0/hypernode.c -o hypernode.lo 
libtool: compile:  cc -I. -I/build/php-hypernode-20200721.074350/build-8.0 -I/build/php-hypernode-20200721.074350/build-8.0/include -I/build/php-hypernode-20200721.074350/build-8.0/main -I/build/php-hypernode-20200721.074350/build-8.0 -I/usr/include/php/20200930 -I/usr/include/php/20200930/main -I/usr/include/php/20200930/TSRM -I/usr/include/php/20200930/Zend -I/usr/include/php/20200930/ext -I/usr/include/php/20200930/ext/date/lib -Wdate-time -D_FORTIFY_SOURCE=2 -DHAVE_CONFIG_H -g -O2 -fdebug-prefix-map=/build/php-hypernode-20200721.074350=. -fstack-protector-strong -Wformat -Werror=format-security -Wall -pedantic -c /build/php-hypernode-20200721.074350/build-8.0/hypernode.c  -fPIC -DPIC -o .libs/hypernode.o
/build/php-hypernode-20200721.074350/build-8.0/hypernode.c: In function 'zm_activate_hypernode':
/build/php-hypernode-20200721.074350/build-8.0/hypernode.c:132:24: error: dereferencing pointer to incomplete type 'fcgi_request' {aka 'struct _fcgi_request'}
  if (getsockopt(request->fd, IPPROTO_TCP, TCP_INFO, (void*)&tcp_info, (socklen_t*)&tcp_info_length)) {
                        ^~
/build/php-hypernode-20200721.074350/build-8.0/hypernode.c:141:59: error: expected ')' before 'TSRMLS_CC'
   http_host = sapi_getenv("HTTP_HOST", strlen("HTTP_HOST") TSRMLS_CC);
                                                           ^~~~~~~~~~
                                                           )
/build/php-hypernode-20200721.074350/build-8.0/hypernode.c:142:65: error: expected ')' before 'TSRMLS_CC'
   remote_addr = sapi_getenv("REMOTE_ADDR", strlen("REMOTE_ADDR") TSRMLS_CC);
                                                                 ^~~~~~~~~~
                                                                 )
At top level:
/build/php-hypernode-20200721.074350/build-8.0/hypernode.c:92:13: warning: 'php_hypernode_init_globals' defined but not used [-Wunused-function]
 static void php_hypernode_init_globals(zend_hypernode_globals *hypernode_globals)
             ^~~~~~~~~~~~~~~~~~~~~~~~~~
/build/php-hypernode-20200721.074350/build-8.0/hypernode.c:48:12: warning: 'le_hypernode' defined but not used [-Wunused-variable]
 static int le_hypernode;
            ^~~~~~~~~~~~
make[2]: *** [Makefile:208: hypernode.lo] Error 1
make[2]: Leaving directory '/build/php-hypernode-20200721.074350/build-8.0'
dh_auto_build: cd build-8.0 && make -j1 returned exit code 2
make[1]: *** [/usr/share/dh-php/pkg-pecl.mk:67: build-8.0-stamp] Error 2
```

Also see https://github.com/zephir-lang/zephir/issues/1865

> Examples of removal from the php team here, there and over there

https://github.com/php/php-src/blob/master/UPGRADING.INTERNALS
https://github.com/php/php-src/commit/e05d230e5265e6041e123659daf7c965132f935f
https://github.com/php/php-src/commit/a1fd706d7d3112be71094a28527e6eebeb3a277a
https://github.com/php/php-src/commit/9977bdf9b3bd235899c980edda12315ad6fa1338


this can be built like:
```
# apt-get install php8.0-dev
# cd php-hypernode/hypernode-src
# phpize
# ./configure
```
(without the whole gbp buildpackage stuff)