### PR TITLE
allow building php-hypernode for php 8.1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,8 @@ Build-Depends:
   php7.2-dev,
   php7.3-dev,
   php7.4-dev,
-  php8.0-dev
+  php8.0-dev,
+  php8.1-dev
 Standards-Version: 3.9.5
 Vcs-Git: git@github.com:ByteInternet/php-hypernode.git
 Vcs-Browser: https://github.com/ByteInternet/php-hypernode

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,7 @@ php-hypernode 220160309.1
   <required>
    <php>
     <min>5.3.0</min>
-    <max>8.1.0</max>
+    <max>8.2.0</max>
     <exclude>6.0.0</exclude>
    </php>
    <pearinstaller>


### PR DESCRIPTION
like https://github.com/ByteInternet/php-hypernode/pull/17/files but PHP 8.1 this time

also see related https://github.com/ByteInternet/php-hypernode/pull/18